### PR TITLE
Remove leading zeros of serial numbers from topics / add tilt to model 25

### DIFF
--- a/warema-bridge/rootfs/srv/bridge.js
+++ b/warema-bridge/rootfs/srv/bridge.js
@@ -20,23 +20,24 @@ var registered_shades = []
 var shade_position = []
 
 function registerDevice(element) {
-  console.log('Registering ' + element.snr)
-  var topic = 'homeassistant/cover/' + element.snr + '/' + element.snr + '/config'
-  var availability_topic = 'warema/' + element.snr + '/availability'
+  snr = element.snr.replace(/^0+/, '')
+  console.log('Registering ' + snr)
+  var topic = 'homeassistant/cover/' + snr + '/' + snr + '/config'
+  var availability_topic = 'warema/' + snr + '/availability'
 
   var base_payload = {
-    name: element.snr,
+    name: snr,
     availability: [
       {topic: 'warema/bridge/state'},
       {topic: availability_topic}
     ],
-    unique_id: element.snr
+    unique_id: snr
   }
 
   var base_device = {
-    identifiers: element.snr,
+    identifiers: snr,
     manufacturer: "Warema",
-    name: element.snr
+    name: snr
   }
 
   var model
@@ -65,11 +66,11 @@ function registerDevice(element) {
         },
         position_open: 0,
         position_closed: 100,
-        command_topic: 'warema/' + element.snr + '/set',
-        position_topic: 'warema/' + element.snr + '/position',
-        tilt_status_topic: 'warema/' + element.snr + '/tilt',
-        set_position_topic: 'warema/' + element.snr + '/set_position',
-        tilt_command_topic: 'warema/' + element.snr + '/set_tilt',
+        command_topic: 'warema/' + snr + '/set',
+        position_topic: 'warema/' + snr + '/position',
+        tilt_status_topic: 'warema/' + snr + '/tilt',
+        set_position_topic: 'warema/' + snr + '/set_position',
+        tilt_command_topic: 'warema/' + snr + '/set_tilt',
         tilt_closed_value: -100,
         tilt_opened_value: 100,
         tilt_min: -100,
@@ -86,11 +87,11 @@ function registerDevice(element) {
         },
         position_open: 0,
         position_closed: 100,
-        command_topic: 'warema/' + element.snr + '/set',
-        position_topic: 'warema/' + element.snr + '/position',
-        tilt_status_topic: 'warema/' + element.snr + '/tilt',
-        set_position_topic: 'warema/' + element.snr + '/set_position',
-        tilt_command_topic: 'warema/' + element.snr + '/set_tilt',
+        command_topic: 'warema/' + snr + '/set',
+        position_topic: 'warema/' + snr + '/position',
+        tilt_status_topic: 'warema/' + snr + '/tilt',
+        set_position_topic: 'warema/' + snr + '/set_position',
+        tilt_command_topic: 'warema/' + snr + '/set_tilt',
         tilt_closed_value: -100,
         tilt_opened_value: 100,
         tilt_min: -100,
@@ -107,9 +108,15 @@ function registerDevice(element) {
         },
         position_open: 0,
         position_closed: 100,
-        command_topic: 'warema/' + element.snr + '/set',
-        position_topic: 'warema/' + element.snr + '/position',
-        set_position_topic: 'warema/' + element.snr + '/set_position',
+        command_topic: 'warema/' + snr + '/set',
+        position_topic: 'warema/' + snr + '/position',
+        tilt_status_topic: 'warema/' + snr + '/tilt',
+        set_position_topic: 'warema/' + snr + '/set_position',
+        tilt_command_topic: 'warema/' + snr + '/set_tilt',
+        tilt_closed_value: -100,
+        tilt_opened_value: 100,
+        tilt_min: -100,
+        tilt_max: 100,
       }
       break
     default:
@@ -119,12 +126,12 @@ function registerDevice(element) {
   }
 
   if (ignoredDevices.includes(element.snr.toString())) {
-    console.log('Ignoring and removing device ' + element.snr + ' (type ' + element.type + ')')
+    console.log('Ignoring and removing device ' + snr + ' (type ' + element.type + ')')
   } else {
-    console.log('Adding device ' + element.snr + ' (type ' + element.type + ')')
+    console.log('Adding device ' + snr + ' (type ' + element.type + ')')
 
     stickUsb.vnBlindAdd(parseInt(element.snr), element.snr.toString());
-    registered_shades += element.snr
+    registered_shades += snr
     client.publish(availability_topic, 'online', {retain: true})
   }
   client.publish(topic, JSON.stringify(payload))

--- a/warema-bridge/rootfs/srv/bridge.js
+++ b/warema-bridge/rootfs/srv/bridge.js
@@ -21,6 +21,7 @@ var shade_position = []
 
 function registerDevice(element) {
   snr = element.snr.replace(/^0+/, '')
+  console.log('Found device of type "' + element.typeStr + '" with type #' + element.type)
   console.log('Registering ' + snr)
   var topic = 'homeassistant/cover/' + snr + '/' + snr + '/config'
   var availability_topic = 'warema/' + snr + '/availability'
@@ -142,6 +143,7 @@ function registerDevices() {
     forceDevices.forEach(element => {
       registerDevice({snr: element, type: 25})
     })
+    client.publish('warema/bridge/state', 'online', {retain: true})
   } else {
     console.log('Scanning...')
     stickUsb.scanDevices({autoAssignBlinds: false});

--- a/warema-bridge/rootfs/srv/package-lock.json
+++ b/warema-bridge/rootfs/srv/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "dependencies": {
                 "mqtt": "^4.2.6",
-                "warema-wms-venetian-blinds": "1.1.18"
+                "warema-wms-venetian-blinds": "1.1.20"
             }
         },
         "node_modules/@serialport/binding-abstract": {
@@ -1138,10 +1138,11 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "node_modules/warema-wms-venetian-blinds": {
-            "version": "1.1.18",
-            "resolved": "https://registry.npmjs.org/warema-wms-venetian-blinds/-/warema-wms-venetian-blinds-1.1.18.tgz",
-            "integrity": "sha512-ID0FziLj8IExW3yqTS9GfqUHOkLuMem+LYN0tIhBEYRQQt8vwG/MnmMDAY6XP52xlkg2AUJg72DnnuD8lFe4oA==",
+            "version": "1.1.20",
+            "resolved": "https://registry.npmjs.org/warema-wms-venetian-blinds/-/warema-wms-venetian-blinds-1.1.20.tgz",
+            "integrity": "sha512-YCNTxb72G5oTSnIyDoNVyyOmZCUW/TjM/lWaFeIlk7dCWM0+soInGK11FdoHibEGPPKlSXVjZWjwP2539aUTzg==",
             "dependencies": {
+                "@serialport/parser-delimiter": ">=9.0.0",
                 "serialport": ">=8.0.0"
             }
         },
@@ -2098,10 +2099,11 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "warema-wms-venetian-blinds": {
-            "version": "1.1.18",
-            "resolved": "https://registry.npmjs.org/warema-wms-venetian-blinds/-/warema-wms-venetian-blinds-1.1.18.tgz",
-            "integrity": "sha512-ID0FziLj8IExW3yqTS9GfqUHOkLuMem+LYN0tIhBEYRQQt8vwG/MnmMDAY6XP52xlkg2AUJg72DnnuD8lFe4oA==",
+            "version": "1.1.20",
+            "resolved": "https://registry.npmjs.org/warema-wms-venetian-blinds/-/warema-wms-venetian-blinds-1.1.20.tgz",
+            "integrity": "sha512-YCNTxb72G5oTSnIyDoNVyyOmZCUW/TjM/lWaFeIlk7dCWM0+soInGK11FdoHibEGPPKlSXVjZWjwP2539aUTzg==",
             "requires": {
+                "@serialport/parser-delimiter": ">=9.0.0",
                 "serialport": ">=8.0.0"
             }
         },

--- a/warema-bridge/rootfs/srv/package.json
+++ b/warema-bridge/rootfs/srv/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
         "mqtt": "^4.2.6",
-        "warema-wms-venetian-blinds": "1.1.18"
+        "warema-wms-venetian-blinds": "1.1.20"
     }
 }


### PR DESCRIPTION
@giannello, thanks for the library
I changed two things to make it work with my blinds. Maybe you are interested in those changes too

1. The serial number of my blinds include leading zeros. The data structures of the callback function do not include those leading zeros, so the state of my blinds was not refreshed. That's why I removed the leading zeros when creating the mqtt topics device registration.
2. My blinds report model 25 but support the tilt command, so I added it here too.