### PR TITLE
Fixed availability, force_devices types, light

### DIFF
--- a/warema-bridge/rootfs/srv/package-lock.json
+++ b/warema-bridge/rootfs/srv/package-lock.json
@@ -1,12 +1,11 @@
 {
-    "name": "srv",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "dependencies": {
                 "mqtt": "^4.2.6",
-                "warema-wms-venetian-blinds": "1.1.18"
+                "warema-wms-venetian-blinds": "2.0.0"
             }
         },
         "node_modules/@serialport/binding-abstract": {
@@ -142,9 +141,9 @@
             }
         },
         "node_modules/balanced-match": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -232,15 +231,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
-        },
-        "node_modules/callback-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/callback-stream/-/callback-stream-1.1.0.tgz",
-            "integrity": "sha1-RwGlEmbwbgbqpx/BcjOCLYdfSQg=",
-            "dependencies": {
-                "inherits": "^2.0.1",
-                "readable-stream": "> 1.0.0 < 3.0.0"
-            }
         },
         "node_modules/chownr": {
             "version": "1.1.4",
@@ -358,14 +348,27 @@
             }
         },
         "node_modules/duplexify": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+            "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
             "dependencies": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
+                "end-of-stream": "^1.4.1",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1",
                 "stream-shift": "^1.0.0"
+            }
+        },
+        "node_modules/duplexify/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/end-of-stream": {
@@ -383,11 +386,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "node_modules/file-uri-to-path": {
             "version": "1.0.0",
@@ -425,9 +423,9 @@
             "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
         },
         "node_modules/glob": {
-            "version": "7.1.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -443,49 +441,31 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/glob-parent": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-            "dependencies": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
-            }
-        },
-        "node_modules/glob-stream": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
-            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
-            "dependencies": {
-                "extend": "^3.0.0",
-                "glob": "^7.1.1",
-                "glob-parent": "^3.1.0",
-                "is-negated-glob": "^1.0.0",
-                "ordered-read-streams": "^1.0.0",
-                "pumpify": "^1.3.5",
-                "readable-stream": "^2.1.5",
-                "remove-trailing-separator": "^1.0.1",
-                "to-absolute-glob": "^2.0.0",
-                "unique-stream": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
         "node_modules/has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "node_modules/help-me": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/help-me/-/help-me-1.1.0.tgz",
-            "integrity": "sha1-jy1QjQYAtKRW2i8IZVbn5cBWo8Y=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
+            "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
             "dependencies": {
-                "callback-stream": "^1.0.2",
-                "glob-stream": "^6.1.0",
-                "through2": "^2.0.1",
-                "xtend": "^4.0.0"
+                "glob": "^7.1.6",
+                "readable-stream": "^3.6.0"
+            }
+        },
+        "node_modules/help-me/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/ieee754": {
@@ -526,26 +506,6 @@
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         },
-        "node_modules/is-absolute": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-            "dependencies": {
-                "is-relative": "^1.0.0",
-                "is-windows": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-fullwidth-code-point": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -557,64 +517,15 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-glob": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-            "dependencies": {
-                "is-extglob": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-negated-glob": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-relative": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-            "dependencies": {
-                "is-unc-path": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-unc-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-            "dependencies": {
-                "unc-path-regex": "^0.1.2"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-windows": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
-        "node_modules/json-stable-stringify-without-jsonify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+        "node_modules/js-sdsl": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
+            "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A=="
         },
         "node_modules/leven": {
             "version": "2.1.0",
@@ -622,6 +533,17 @@
             "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/mimic-response": {
@@ -657,22 +579,26 @@
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
         },
         "node_modules/mqtt": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.6.tgz",
-            "integrity": "sha512-GpxVObyOzL0CGPBqo6B04GinN8JLk12NRYAIkYvARd9ZCoJKevvOyCaWK6bdK/kFSDj3LPDnCsJbezzNlsi87Q==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.4.tgz",
+            "integrity": "sha512-yAVDfVHz3Cjn6K68z54mf7fTni/AWsPhiEsRwZSvet2wO47R6NFUn2psWxYIph2JxWtL3ZKa/da8pjJKSaXPdQ==",
             "dependencies": {
                 "commist": "^1.0.0",
                 "concat-stream": "^2.0.0",
                 "debug": "^4.1.1",
-                "help-me": "^1.0.1",
+                "duplexify": "^4.1.1",
+                "help-me": "^3.0.0",
                 "inherits": "^2.0.3",
+                "lru-cache": "^6.0.0",
                 "minimist": "^1.2.5",
-                "mqtt-packet": "^6.6.0",
+                "mqtt-packet": "^6.8.0",
+                "number-allocator": "^1.0.9",
                 "pump": "^3.0.0",
                 "readable-stream": "^3.6.0",
                 "reinterval": "^1.1.0",
+                "rfdc": "^1.3.0",
                 "split2": "^3.1.0",
-                "ws": "^7.3.1",
+                "ws": "^7.5.5",
                 "xtend": "^4.0.2"
             },
             "bin": {
@@ -746,6 +672,15 @@
                 "set-blocking": "~2.0.0"
             }
         },
+        "node_modules/number-allocator": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.9.tgz",
+            "integrity": "sha512-sIIF0dZKMs3roPUD7rLreH8H3x47QKV9dHZ+PeSnH24gL0CxKxz/823woGZC0hLBSb2Ar/rOOeHiNbnPBum/Mw==",
+            "dependencies": {
+                "debug": "^4.3.1",
+                "js-sdsl": "^2.1.2"
+            }
+        },
         "node_modules/number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -769,19 +704,6 @@
             "dependencies": {
                 "wrappy": "1"
             }
-        },
-        "node_modules/ordered-read-streams": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
-            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
-            "dependencies": {
-                "readable-stream": "^2.0.1"
-            }
-        },
-        "node_modules/path-dirname": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
@@ -833,25 +755,6 @@
                 "once": "^1.3.1"
             }
         },
-        "node_modules/pumpify": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-            "dependencies": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
-            }
-        },
-        "node_modules/pumpify/node_modules/pump": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
         "node_modules/rc": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -885,10 +788,10 @@
             "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
             "integrity": "sha1-M2Hs+jymwYKDOA3Qu5VG85D17Oc="
         },
-        "node_modules/remove-trailing-separator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+        "node_modules/rfdc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
         },
         "node_modules/safe-buffer": {
             "version": "5.1.2",
@@ -1069,36 +972,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/through2": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-            "dependencies": {
-                "readable-stream": "~2.3.6",
-                "xtend": "~4.0.1"
-            }
-        },
-        "node_modules/through2-filter": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
-            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
-            "dependencies": {
-                "through2": "~2.0.0",
-                "xtend": "~4.0.0"
-            }
-        },
-        "node_modules/to-absolute-glob": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
-            "dependencies": {
-                "is-absolute": "^1.0.0",
-                "is-negated-glob": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -1115,33 +988,17 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
-        "node_modules/unc-path-regex": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/unique-stream": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
-            "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
-            "dependencies": {
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "through2-filter": "^3.0.0"
-            }
-        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "node_modules/warema-wms-venetian-blinds": {
-            "version": "1.1.18",
-            "resolved": "https://registry.npmjs.org/warema-wms-venetian-blinds/-/warema-wms-venetian-blinds-1.1.18.tgz",
-            "integrity": "sha512-ID0FziLj8IExW3yqTS9GfqUHOkLuMem+LYN0tIhBEYRQQt8vwG/MnmMDAY6XP52xlkg2AUJg72DnnuD8lFe4oA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/warema-wms-venetian-blinds/-/warema-wms-venetian-blinds-2.0.0.tgz",
+            "integrity": "sha512-8kUESu0MyFRLhInhohpPQAtCKTxZqDDBiYC0fVnv9Spb+fIrVPpFToPC31PFAjIYkg7pe4I8pBSXIC22gI80Fw==",
             "dependencies": {
+                "@serialport/parser-delimiter": ">=9.0.0",
                 "serialport": ">=8.0.0"
             }
         },
@@ -1164,9 +1021,9 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "node_modules/ws": {
-            "version": "7.4.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-            "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+            "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
             "engines": {
                 "node": ">=8.3.0"
             },
@@ -1190,6 +1047,11 @@
             "engines": {
                 "node": ">=0.4"
             }
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
     },
     "dependencies": {
@@ -1289,9 +1151,9 @@
             }
         },
         "balanced-match": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "base64-js": {
             "version": "1.5.1",
@@ -1350,15 +1212,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
-        },
-        "callback-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/callback-stream/-/callback-stream-1.1.0.tgz",
-            "integrity": "sha1-RwGlEmbwbgbqpx/BcjOCLYdfSQg=",
-            "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "> 1.0.0 < 3.0.0"
-            }
         },
         "chownr": {
             "version": "1.1.4",
@@ -1449,14 +1302,26 @@
             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
         },
         "duplexify": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+            "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
             "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
+                "end-of-stream": "^1.4.1",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1",
                 "stream-shift": "^1.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
             }
         },
         "end-of-stream": {
@@ -1471,11 +1336,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
-        },
-        "extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "file-uri-to-path": {
             "version": "1.0.0",
@@ -1513,9 +1373,9 @@
             "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
         },
         "glob": {
-            "version": "7.1.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -1525,46 +1385,30 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
-        "glob-parent": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-            "requires": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
-            }
-        },
-        "glob-stream": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
-            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
-            "requires": {
-                "extend": "^3.0.0",
-                "glob": "^7.1.1",
-                "glob-parent": "^3.1.0",
-                "is-negated-glob": "^1.0.0",
-                "ordered-read-streams": "^1.0.0",
-                "pumpify": "^1.3.5",
-                "readable-stream": "^2.1.5",
-                "remove-trailing-separator": "^1.0.1",
-                "to-absolute-glob": "^2.0.0",
-                "unique-stream": "^2.0.2"
-            }
-        },
         "has-unicode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "help-me": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/help-me/-/help-me-1.1.0.tgz",
-            "integrity": "sha1-jy1QjQYAtKRW2i8IZVbn5cBWo8Y=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
+            "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
             "requires": {
-                "callback-stream": "^1.0.2",
-                "glob-stream": "^6.1.0",
-                "through2": "^2.0.1",
-                "xtend": "^4.0.0"
+                "glob": "^7.1.6",
+                "readable-stream": "^3.6.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
             }
         },
         "ieee754": {
@@ -1591,20 +1435,6 @@
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         },
-        "is-absolute": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-            "requires": {
-                "is-relative": "^1.0.0",
-                "is-windows": "^1.0.1"
-            }
-        },
-        "is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-        },
         "is-fullwidth-code-point": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -1613,54 +1443,28 @@
                 "number-is-nan": "^1.0.0"
             }
         },
-        "is-glob": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-            "requires": {
-                "is-extglob": "^2.1.0"
-            }
-        },
-        "is-negated-glob": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
-        },
-        "is-relative": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-            "requires": {
-                "is-unc-path": "^1.0.0"
-            }
-        },
-        "is-unc-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-            "requires": {
-                "unc-path-regex": "^0.1.2"
-            }
-        },
-        "is-windows": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
-        "json-stable-stringify-without-jsonify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+        "js-sdsl": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
+            "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A=="
         },
         "leven": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
             "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+        },
+        "lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "requires": {
+                "yallist": "^4.0.0"
+            }
         },
         "mimic-response": {
             "version": "2.1.0",
@@ -1686,22 +1490,26 @@
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
         },
         "mqtt": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.6.tgz",
-            "integrity": "sha512-GpxVObyOzL0CGPBqo6B04GinN8JLk12NRYAIkYvARd9ZCoJKevvOyCaWK6bdK/kFSDj3LPDnCsJbezzNlsi87Q==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.4.tgz",
+            "integrity": "sha512-yAVDfVHz3Cjn6K68z54mf7fTni/AWsPhiEsRwZSvet2wO47R6NFUn2psWxYIph2JxWtL3ZKa/da8pjJKSaXPdQ==",
             "requires": {
                 "commist": "^1.0.0",
                 "concat-stream": "^2.0.0",
                 "debug": "^4.1.1",
-                "help-me": "^1.0.1",
+                "duplexify": "^4.1.1",
+                "help-me": "^3.0.0",
                 "inherits": "^2.0.3",
+                "lru-cache": "^6.0.0",
                 "minimist": "^1.2.5",
-                "mqtt-packet": "^6.6.0",
+                "mqtt-packet": "^6.8.0",
+                "number-allocator": "^1.0.9",
                 "pump": "^3.0.0",
                 "readable-stream": "^3.6.0",
                 "reinterval": "^1.1.0",
+                "rfdc": "^1.3.0",
                 "split2": "^3.1.0",
-                "ws": "^7.3.1",
+                "ws": "^7.5.5",
                 "xtend": "^4.0.2"
             },
             "dependencies": {
@@ -1766,6 +1574,15 @@
                 "set-blocking": "~2.0.0"
             }
         },
+        "number-allocator": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.9.tgz",
+            "integrity": "sha512-sIIF0dZKMs3roPUD7rLreH8H3x47QKV9dHZ+PeSnH24gL0CxKxz/823woGZC0hLBSb2Ar/rOOeHiNbnPBum/Mw==",
+            "requires": {
+                "debug": "^4.3.1",
+                "js-sdsl": "^2.1.2"
+            }
+        },
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -1783,19 +1600,6 @@
             "requires": {
                 "wrappy": "1"
             }
-        },
-        "ordered-read-streams": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
-            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
-            "requires": {
-                "readable-stream": "^2.0.1"
-            }
-        },
-        "path-dirname": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -1838,27 +1642,6 @@
                 "once": "^1.3.1"
             }
         },
-        "pumpify": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-            "requires": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
-            },
-            "dependencies": {
-                "pump": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-                    "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-                    "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
-                    }
-                }
-            }
-        },
         "rc": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -1889,10 +1672,10 @@
             "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
             "integrity": "sha1-M2Hs+jymwYKDOA3Qu5VG85D17Oc="
         },
-        "remove-trailing-separator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+        "rfdc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
         },
         "safe-buffer": {
             "version": "5.1.2",
@@ -2038,33 +1821,6 @@
                 }
             }
         },
-        "through2": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-            "requires": {
-                "readable-stream": "~2.3.6",
-                "xtend": "~4.0.1"
-            }
-        },
-        "through2-filter": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
-            "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
-            "requires": {
-                "through2": "~2.0.0",
-                "xtend": "~4.0.0"
-            }
-        },
-        "to-absolute-glob": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
-            "requires": {
-                "is-absolute": "^1.0.0",
-                "is-negated-glob": "^1.0.0"
-            }
-        },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -2078,30 +1834,17 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
-        "unc-path-regex": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
-        },
-        "unique-stream": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
-            "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
-            "requires": {
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "through2-filter": "^3.0.0"
-            }
-        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "warema-wms-venetian-blinds": {
-            "version": "1.1.18",
-            "resolved": "https://registry.npmjs.org/warema-wms-venetian-blinds/-/warema-wms-venetian-blinds-1.1.18.tgz",
-            "integrity": "sha512-ID0FziLj8IExW3yqTS9GfqUHOkLuMem+LYN0tIhBEYRQQt8vwG/MnmMDAY6XP52xlkg2AUJg72DnnuD8lFe4oA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/warema-wms-venetian-blinds/-/warema-wms-venetian-blinds-2.0.0.tgz",
+            "integrity": "sha512-8kUESu0MyFRLhInhohpPQAtCKTxZqDDBiYC0fVnv9Spb+fIrVPpFToPC31PFAjIYkg7pe4I8pBSXIC22gI80Fw==",
             "requires": {
+                "@serialport/parser-delimiter": ">=9.0.0",
                 "serialport": ">=8.0.0"
             }
         },
@@ -2124,15 +1867,20 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "ws": {
-            "version": "7.4.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-            "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+            "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
             "requires": {}
         },
         "xtend": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        },
+        "yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
     }
 }

--- a/warema-bridge/rootfs/srv/package.json
+++ b/warema-bridge/rootfs/srv/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
         "mqtt": "^4.2.6",
-        "warema-wms-venetian-blinds": "1.1.18"
+        "warema-wms-venetian-blinds": "2.0.0"
     }
 }


### PR DESCRIPTION
…e (via optional syntax passed via docker, snr:type. If no type is given, 25 stays default)

2) Added a “fake” type “1000” for LED stripes that register in HomeAssistant as light and can be managed as such
3) Updated to latest version of warema-venetian-blinds, which gets rid of some unwanted confirmation messages in the logs and updates the other dependencies